### PR TITLE
Use upper-case args in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ pt.time_benchmark(foo, x=129, n=100)
 ```
 and this will print the results of the time benchmark, with raw results similar to those that `timeit.repeat()` returns, but unlike it, `pt.time_benchmark()` returns mean raw time per function run, not overall; in additional, you will see some summaries of the results.
 
-The above call did actually run  `timeit.repeat()` function, with the default configuration of `number=100_000` and `repeat=5`. If you want to change any of these, you can use arguments `Number` and `Repeat`, correspondigly:
+The above call did actually run  `timeit.repeat()` function, with the default configuration of `Number=100_000` and `Repeat=5`. If you want to change any of these, you can use arguments `Number` and `Repeat`, correspondigly:
 
 ```python
 pt.time_benchmark(foo, x=129, n=100, Number=1000)
@@ -38,7 +38,7 @@ pt.time_benchmark(foo, x=129, n=100, Number=1000, Repeat=2)
 
 These calls do not change the default settings so you use the arguments' values on the fly. Later you will learn how to change the default settings and the settings for a particular function.
 
-> Some of you may wonder why the `Number` and `Repeat` arguments violate what we can call the Pythonic style, by using a capital first letter for function arguments. The reason is simple: I wanted to minimize a risk of conflicts that would happen when benchmarking (or testing) a function with any of the arguments `number` or `repeat` (or both). A chance that a Python function will have a `Number` or a `Repeat` argument is rather small. If that happens, however, you can use `functools.partial()` to overcome the problem:
+> Some of you may wonder why the `Number` and `Repeat` arguments violate what we can call the Pythonic style, by using a capital first letter for function arguments. The reason is simple: I wanted to minimize a risk of conflicts that would happen when benchmarking (or testing) a function with any of the arguments `Number` or `Repeat` (or both). A chance that a Python function will have a `Number` or a `Repeat` argument is rather small. If that happens, however, you can use `functools.partial()` to overcome the problem:
 
 ```python
 from functools import partial
@@ -196,7 +196,7 @@ To create a performance test for a function, you likely need to know how it beha
 ```python
 >>> import perftester as pt
 >>> def f(n): return sum(map(lambda i: i**0.5, range(n)))
->>> pt.config.set(f, "time", number=1000)
+>>> pt.config.set(f, "time", Number=1000)
 >>> b_100_time = pt.time_benchmark(f, n=100)
 >>> b_100_memory = pt.memory_usage_benchmark(f, n=100)
 >>> b_1000_time = pt.time_benchmark(f, n=1000)
@@ -313,7 +313,7 @@ The whole configuration is stored in the `pt.config` object, which you can easil
 
 ```python
 >>> def f(n): return list(range(n))
->>> pt.config.set(f, "time", number=10_000, repeat=1)
+>>> pt.config.set(f, "time", Number=10_000, Repeat=1)
 
 ```
 
@@ -326,7 +326,7 @@ When you use `perftester` as a command-line tool, you can modify `pt.config` in 
 import perftester as pt
 
 # shorten the tests
-pt.config.set_defaults("time", number=10_000, repeat=3) 
+pt.config.set_defaults("time", Number=10_000, Repeat=3) 
 
 # log the results to file (they will be printed in the console anyway)
 pt.config.log_to_file = True

--- a/docs/benchmarking_against_another_function.md
+++ b/docs/benchmarking_against_another_function.md
@@ -26,7 +26,7 @@ Let's check the performance of both functions for large `n`, for which the way m
 
 ```python
 >>> import perftester as pt
->>> pt.config.set_defaults("time", number=25, repeat=3) # change defaults - both functions will use these settings
+>>> pt.config.set_defaults("time", Number=25, Repeat=3) # change defaults - both functions will use these settings
 >>> n_for_comparison = 10_000_000
 
 # Actual benchmarks

--- a/docs/use_case_raw_time_testing.md
+++ b/docs/use_case_raw_time_testing.md
@@ -31,7 +31,7 @@ The first step is import `perftester`:
 This creates object `pt.config`, which all `perftester` functions use, and which you can use to change (or check) settings. We will use `config` to decrease the number of runs of the function, as with the default million of runs we would have to wait way too long:
 
 ```python
->>> pt.config.set(f, "time", repeat=3, number=5)
+>>> pt.config.set(f, "time", Repeat=3, Number=5)
 
 ```
 

--- a/docs/use_of_config.md
+++ b/docs/use_of_config.md
@@ -94,7 +94,7 @@ Use this method to change a setting for a particular function:
 For `which="time"`, you can change both settings at the same time:
 
 ```python
->>> pt.config.set(f1, "time", repeat=3, number=1000)
+>>> pt.config.set(f1, "time", Repeat=3, Number=1000)
 >>> pt.config.get_setting(f1, "time", "repeat")
 3
 >>> pt.config.get_setting(f1, "time", "number")
@@ -107,7 +107,7 @@ For `which="time"`, you can change both settings at the same time:
 This method can be used in the very same way as above-described `.set()`, but this one changes the default settings:
 
 ```python
->>> pt.config.set_defaults("time", repeat=3, number=5000)
+>>> pt.config.set_defaults("time", Repeat=3, Number=5000)
 >>> pt.config.defaults
 {'time': {'number': 5000, 'repeat': 3}, 'memory': {'repeat': 1}}
 
@@ -164,7 +164,7 @@ The `.digits_for_printing` controls the way `pp` rounds numbers, but also the wa
 
 >>> pt.config.digits_for_printing = 3
 >>> pt.pp({"a": 1.123123, "b": 3434.3434})
-{'a': 1.12, 'b': 3430}
+{'a': 1.12, 'b': 3430.0}
 
 >>> pt.config.digits_for_printing = 5
 >>> pt.pp({"a": 1.123123, "b": 3434.3434})

--- a/perftester/perftester.py
+++ b/perftester/perftester.py
@@ -285,7 +285,7 @@ class Config:
         ]
         self.memory_benchmark = min(max(r) for r in memory_results)
 
-    def set_defaults(self, which, number=None, repeat=None):
+    def set_defaults(self, which, number=None, repeat=None, Number=None, Repeat=None):
         """Change the default settings.
 
         Beware! This does not change particular settings for a particular test,
@@ -302,6 +302,11 @@ class Config:
             repeat (int, optional): passed to timeit.repeat as repeat.
                 Defaults to None.
         """
+        if number is None and Number is not None:
+            number = Number
+        if repeat is None and Repeat is not None:
+            repeat = Repeat
+
         self._check_args(lambda: 0, which, number, repeat)
 
         if number is not None:
@@ -309,7 +314,7 @@ class Config:
         if repeat is not None:
             self.defaults[which]["repeat"] = repeat
 
-    def set(self, func, which, number=None, repeat=None):
+    def set(self, func, which, number=None, repeat=None, Number=None, Repeat=None):
         """Set a particular argument.
 
         Args:
@@ -322,6 +327,11 @@ class Config:
                 as repeat; for memory tests, the number of runs of the test.
                 Defaults to None.
         """
+        if number is None and Number is not None:
+            number = Number
+        if repeat is None and Repeat is not None:
+            repeat = Repeat
+
         self._check_args(func, which, number, repeat)
 
         if func not in self.settings.keys():
@@ -371,6 +381,12 @@ class Config:
                 "For memory tests, you can only set repeat, not number.",
             )
 
+        if number is not None:
+            if int(number) == number:
+                number = int(number)
+        if repeat is not None:
+            if int(repeat) == repeat:
+                repeat = int(repeat)
         check_instance(
             number,
             (int, None),
@@ -380,7 +396,6 @@ class Config:
                 f"{type(number).__name__}"
             ),
         )
-
         check_instance(
             repeat,
             (int, None),
@@ -805,7 +820,7 @@ def pp(*args):
     0.1222
     >>> pp(dict(a=.12121212, b=23.234234234), ["system failure", 345345.345])
     {'a': 0.1212, 'b': 23.23}
-    ['system failure', 345300]
+    ['system failure', 345300.0]
     """
     for arg in args:
         pprint(

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ extras_requirements = {
 
 setuptools.setup(
     name="perftester",
-    version="0.4.0",
+    version="0.5.0",
     author="Nyggus",
     author_email="nyggus@gmail.com",
     description="Lightweight performance testing in Python",

--- a/tests/README.md
+++ b/tests/README.md
@@ -8,7 +8,7 @@ The `perftester` package uses only the `doctest` framework for unit testing. As 
 
 Initially, [the docs folder](../docs/) contained Markdown files while [the tests folder](./) contained text files (as text files are also a good way of writing doctests). However, it quickly occurred that Markdown files are a little more readable, especially in a browser, so all testing files are now formatted using Markdown. The testing files here, however, has much less explanation, limited mainly to explanation helping the reader understand the tests or some of their aspects.
 
-> Note that `perftester` is now covered by many testes, so it takes some time to run them. Therefore, some examples use low values of `number` and `repeat`, so that the tests do not take an hour or so. In real performance testing, you should use relevant values of these arguments.
+> Note that `perftester` is now covered by many testes, so it takes some time to run them. Therefore, some examples use low values of `Number` and `Repeat`, so that the tests do not take an hour or so. In real performance testing, you should use relevant values of these arguments.
 
 
 ## Operating system

--- a/tests/doctest_config.md
+++ b/tests/doctest_config.md
@@ -11,32 +11,32 @@ You can read how to use `pt.config` [here](../docs/use_of_config.md). Below, you
 {'time': {'number': 100000, 'repeat': 5}, 'memory': {'repeat': 1}}
 
 >>> original_defaults = pt.config.defaults
->>> pt.config.set_defaults("time", number=100)
+>>> pt.config.set_defaults("time", Number=100)
 >>> pt.config.defaults
 {'time': {'number': 100, 'repeat': 5}, 'memory': {'repeat': 1}}
 
->>> pt.config.set_defaults("time", repeat=20)
+>>> pt.config.set_defaults("time", Repeat=20)
 >>> pt.config.defaults
 {'time': {'number': 100, 'repeat': 20}, 'memory': {'repeat': 1}}
->>> pt.config.set_defaults("time", repeat=2, number=7)
+>>> pt.config.set_defaults("time", Repeat=2, Number=7)
 >>> pt.config.defaults
 {'time': {'number': 7, 'repeat': 2}, 'memory': {'repeat': 1}}
 
->>> pt.config.set_defaults("memory", repeat=100)
+>>> pt.config.set_defaults("memory", Repeat=100)
 >>> pt.config.defaults
 {'time': {'number': 7, 'repeat': 2}, 'memory': {'repeat': 100}}
 
->>> pt.config.set_defaults("memory", number=100)
+>>> pt.config.set_defaults("memory", Number=100)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: For memory tests, you can only set repeat, not number.
 
->>> pt.config.set_defaults("memory", number=100, repeat=5)
+>>> pt.config.set_defaults("memory", Number=100, Repeat=5)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: For memory tests, you can only set repeat, not number.
 
->>> pt.config.set_defaults("memory", repeat=5, number=100)
+>>> pt.config.set_defaults("memory", Repeat=5, Number=100)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: For memory tests, you can only set repeat, not number.
@@ -49,28 +49,28 @@ perftester.perftester.IncorrectArgumentError: For memory tests, you can only set
 
 ```python
 >>> def f(): pass
->>> pt.config.set(f, "time", number=20, repeat=10)
+>>> pt.config.set(f, "time", Number=20, Repeat=10)
 >>> pt.config.settings[f]
 {'memory': {'repeat': 100}, 'time': {'number': 20, 'repeat': 10}}
 
->>> pt.config.set(f, "time", number=50)
+>>> pt.config.set(f, "time", Number=50)
 >>> pt.config.settings[f]
 {'memory': {'repeat': 100}, 'time': {'number': 50, 'repeat': 10}}
 
->>> pt.config.set(f, "time", repeat=5)
+>>> pt.config.set(f, "time", Repeat=5)
 >>> pt.config.settings[f]
 {'memory': {'repeat': 100}, 'time': {'number': 50, 'repeat': 5}}
 
->>> pt.config.set(f, "memory", repeat=5)
+>>> pt.config.set(f, "memory", Repeat=5)
 >>> pt.config.settings[f]
 {'memory': {'repeat': 5}, 'time': {'number': 50, 'repeat': 5}}
 
->>> pt.config.set(f, "memory", number=5)
+>>> pt.config.set(f, "memory", Number=5)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: For memory tests, you can only set repeat, not number.
 
->>> pt.config.set(f, "memory", number=5, repeat=10)
+>>> pt.config.set(f, "memory", Number=5, Repeat=10)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: For memory tests, you can only set repeat, not number.
@@ -80,19 +80,19 @@ perftester.perftester.IncorrectArgumentError: For memory tests, you can only set
 ## Incorrect which argument
 
 ```python
->>> pt.config.set(f, "memorys", repeat=5)
+>>> pt.config.set(f, "memorys", Repeat=5)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: Argument which must be str from among memory, time
->>> pt.config.set(f, "times", repeat=5)
+>>> pt.config.set(f, "times", Repeat=5)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: Argument which must be str from among memory, time
->>> pt.config.set_defaults(f, "memorys", repeat=5)
+>>> pt.config.set_defaults(f, "memorys", Repeat=5)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: Argument which must be str from among memory, time
->>> pt.config.set_defaults(f, "times", repeat=5)
+>>> pt.config.set_defaults(f, "times", Repeat=5)
 Traceback (most recent call last):
     ...
 perftester.perftester.IncorrectArgumentError: Argument which must be str from among memory, time

--- a/tests/doctest_function_floats.md
+++ b/tests/doctest_function_floats.md
@@ -92,7 +92,7 @@ In some tests, we will the following function:
 >>> variance(x_short), variance_2(x_short), variance_3(x_short), variance_4(x_short) #doctest: +ELLIPSIS
 (3.5..., 3.5..., 3.5..., 3.5...)
 
->>> pt.config.set_defaults("time", number=100)
+>>> pt.config.set_defaults("time", Number=100)
 >>> var_perf_time = pt.time_benchmark(variance, x_short)
 >>> var_perf_2_time = pt.time_benchmark(variance_2, x_short)
 >>> var_perf_3_time = pt.time_benchmark(variance_3, x_short)

--- a/tests/perftester_for_testing.py
+++ b/tests/perftester_for_testing.py
@@ -11,8 +11,8 @@ def f2():
     pass
 
 
-pt.config.set(f, "time", repeat=1, number=1)
-pt.config.set(f2, "time", repeat=10, number=10_000)
+pt.config.set(f, "time", Repeat=1, Number=1)
+pt.config.set(f2, "time", Repeat=10, Number=10_000)
 
 
 def perftester_f():


### PR DESCRIPTION
For consistency, changing settings (`number` and `repeat`) in `config` are now done using `Number` and `Repeat` arguments. This is consistent with benchmarking and testing functions.

For backward compatibility, the previous arguments `number` and `repeat` can be used too, at least for some time.